### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import express, {Request, Response} from 'express';
+import express from 'express';
 import {json} from 'body-parser';
 import http from 'http';
 import {Server} from 'socket.io';


### PR DESCRIPTION
Remove the unused named imports from the Express import statement in `src/index.ts`, line 4.

Best fix (no behavior change):
- Change:
  - `import express, {Request, Response} from 'express';`
- To:
  - `import express from 'express';`

This keeps runtime functionality identical and resolves the CodeQL finding cleanly without touching any other logic, routes, or socket handling.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._