### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/controllers/contactsController.ts
+++ b/src/controllers/contactsController.ts
@@ -1,6 +1,5 @@
 import {Request, Response} from 'express';
 import pool from '../models/db';
-import { validate as isUuid } from "uuid";
 
 export const fetchContacts = async (req: Request, res: Response) => {
     try{


### PR DESCRIPTION
Remove the unused `isUuid` import from `src/controllers/contactsController.ts`.

Best fix (without changing functionality): delete only the import line
```ts
import { validate as isUuid } from "uuid";
```
This preserves runtime behavior and resolves the CodeQL warning. No additional methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._